### PR TITLE
Fixed race condition issues for fresh installs

### DIFF
--- a/charts/posthog/templates/secrets.yaml
+++ b/charts/posthog/templates/secrets.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+     "helm.sh/hook": pre-install
+     "helm.sh/hook-weight": "-10"
 type: Opaque
 data:
   {{ if .Values.posthogSecret }}

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -275,7 +275,7 @@ hooks:
         memory: 1000Mi
     # Defaults to performing the DB migration job after the install/upgrade. 
     # Can be overridden to "pre-install,pre-upgrade" with caution to perform migrations that are sometimes required for the deployment to become healthy
-    hookAnnotation: "post-install,post-upgrade"
+    hookAnnotation: "pre-install,post-upgrade"
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
As we use "atomic" deploys as part of our continuous deployment we have this issue:

## Before this PR
**Option 1**
* Chart is installed with migration job "post-install"
* The deployment never becomes healthy as the DB migrations have not been performed
* After helm times-out the release is uninstalled

**Option 2**
* Chart is installed with migration job "pre-install"
* The job fails as the Secret containing needed values is not created (helm will create it after the migration job completes)
* After helm times-out the release is uninstalled


## With this PR
* Migration job helmAnnotation default is changed to `pre-install,post-upgrade` (makes sense in the context of a pessimistic upgrade plan)
* Secret also has a "pre-install" annotation and a lower weight than the migration job ensuring the Secret is always present no matter what the configuration
