### PR TITLE
Update for patch-1.21.0 release

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://camo.githubusercontent.com/11f72f57f33d7d34807bafc1314844f7a91bcde
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.4.7
+version: 1.4.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/ChartV3.yaml
+++ b/charts/posthog/ChartV3.yaml
@@ -15,7 +15,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.4.7
+version: 1.4.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: posthog/posthog
-  tag: release-1.21.0
+  tag: patch-1.21.0
   pullPolicy: IfNotPresent
 
 posthogSecret: ""


### PR DESCRIPTION
As soon as [the `patch-1.21.0` docker image](https://hub.docker.com/repository/registry-1.docker.io/posthog/posthog/builds/789b83fe-28fd-4a3c-8018-046ee12a20ad) is built, this can be merged.

The image will contain 1.21.0 and this fix: https://github.com/PostHog/posthog/pull/3426