### PR TITLE
Allow existing posthog secret to be used

### DIFF
--- a/charts/posthog/templates/beat-deployment.yaml
+++ b/charts/posthog/templates/beat-deployment.yaml
@@ -67,8 +67,13 @@ spec:
         - name: SECRET_KEY
           valueFrom:
             secretKeyRef:
+            {{- if .Values.posthogExistingSecret }}
+              name: {{ .Values.posthogExistingSecret }}
+              key: {{ .Values.posthogExistingSecretKey }}
+            {{- else }}
               name: {{ template "posthog.fullname" . }}
               key: posthog-secret
+            {{- end }}
         - name: POSTHOG_DB_USER
           value: {{ default "posthog" .Values.postgresql.postgresqlUsername | quote }}
         - name: POSTHOG_DB_NAME

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -52,8 +52,13 @@ spec:
         - name: SECRET_KEY
           valueFrom:
             secretKeyRef:
+            {{- if .Values.posthogExistingSecret }}
+              name: {{ .Values.posthogExistingSecret }}
+              key: {{ .Values.posthogExistingSecretKey }}
+            {{- else }}
               name: {{ template "posthog.fullname" . }}
               key: posthog-secret
+            {{- end }}
         - name: POSTHOG_DB_USER
           value: {{ default "posthog" .Values.postgresql.postgresqlUsername | quote }}
         - name: POSTHOG_DB_NAME

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -70,8 +70,13 @@ spec:
         - name: SECRET_KEY
           valueFrom:
             secretKeyRef:
+            {{- if .Values.posthogExistingSecret }}
+              name: {{ .Values.posthogExistingSecret }}
+              key: {{ .Values.posthogExistingSecretKey }}
+            {{- else }}
               name: {{ template "posthog.fullname" . }}
               key: posthog-secret
+            {{- end }}
         - name: POSTHOG_DB_USER
           value: {{ default "posthog" .Values.postgresql.postgresqlUsername | quote }}
         - name: POSTHOG_DB_NAME

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -71,8 +71,13 @@ spec:
         - name: SECRET_KEY
           valueFrom:
             secretKeyRef:
+            {{- if .Values.posthogExistingSecret }}
+              name: {{ .Values.posthogExistingSecret }}
+              key: {{ .Values.posthogExistingSecretKey }}
+            {{- else }}
               name: {{ template "posthog.fullname" . }}
               key: posthog-secret
+            {{- end }}
         - name: POSTHOG_DB_USER
           value: {{ default "posthog" .Values.postgresql.postgresqlUsername | quote }}
         - name: POSTHOG_DB_NAME

--- a/charts/posthog/templates/workers-deployment.yaml
+++ b/charts/posthog/templates/workers-deployment.yaml
@@ -70,8 +70,13 @@ spec:
         - name: SECRET_KEY
           valueFrom:
             secretKeyRef:
+            {{- if .Values.posthogExistingSecret }}
+              name: {{ .Values.posthogExistingSecret }}
+              key: {{ .Values.posthogExistingSecretKey }}
+            {{- else }}
               name: {{ template "posthog.fullname" . }}
               key: posthog-secret
+            {{- end }}
         - name: POSTHOG_DB_USER
           value: {{ default "posthog" .Values.postgresql.postgresqlUsername | quote }}
         - name: POSTHOG_DB_NAME

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -7,6 +7,9 @@ image:
   pullPolicy: IfNotPresent
 
 posthogSecret: ""
+## Use existing secret (ignores posthogSecret)
+# posthogExistingSecret:
+# posthogExistingSecretKey:
 
 env: []
 
@@ -195,7 +198,7 @@ postgresql:
 redis:
   enabled: true
   nameOverride: posthog-redis
-  # The following variables are only used when internal PG is disabled
+  # The following variables are only used when internal Redis is disabled
   # host: redis
   # Just omit the password field if your redis cluster doesn't use password
   # password: redis


### PR DESCRIPTION
This allows storing the posthog secret in a [sealed secret](https://github.com/bitnami-labs/sealed-secrets).