### PR TITLE
Added ingress.scheme to better support https within SITE_URL

### DIFF
--- a/charts/posthog/README.md
+++ b/charts/posthog/README.md
@@ -109,6 +109,7 @@ Parameter                                            | Description              
 `ingress.annotations`                                | Ingress annotations                                                                                        | `{}`
 `ingress.hostname`                                   | URL to address your PostHog installation                                                                   | `posthog.local`
 `ingress.path`                                       | path to address your PostHog installation                                                                  | `/`
+`ingress.scheme`                                     | Scheme used by SITE_URL                                                                                    | `http`
 `ingress.tls`                                        | Ingress TLS configuration                                                                                  | `[]`
 `postgresql.enabled`                                 | Deploy postgres server (see below)                                                                         | `true`
 `postgresql.postgresqlDatabase`                      | Postgres database name                                                                                     | `posthog`
@@ -179,5 +180,4 @@ To avoid issues when upgrading this chart, provide `redis.password` for subseque
 
 ## Ingress
 
-This chart provides support for Ingress resource. If you have an available Ingress Controller such as Nginx or Traefik you maybe want to set `ingress.enabled` to true and choose an `ingress.hostname` for the URL. Then, you should be able to access the installation using that address.
-
+This chart provides support for Ingress resource. If you have an available Ingress Controller such as Nginx or Traefik you maybe want to set `ingress.enabled` to true and choose an `ingress.hostname` for the URL. Then, you should be able to access the installation using that address. The `ingress.hostname` is also used to set the `SITE_URL` environment variable within the chart. Providing an `ingress.scheme` will modify the scheme set for the `SITE_URL` as well. It defaults to `http` but can be set to `https` if applicable. 

--- a/charts/posthog/templates/beat-deployment.yaml
+++ b/charts/posthog/templates/beat-deployment.yaml
@@ -63,7 +63,7 @@ spec:
         - containerPort: {{ .Values.service.internalPort }}
         env:
         - name: SITE_URL 
-          value: {{ default "http://127.0.0.1:8000" .Values.ingress.hostname | quote }} 
+          value: {{ printf "%s://%s" .Values.ingress.scheme .Values.ingress.hostname | quote }}
         - name: SECRET_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -66,7 +66,7 @@ spec:
         - containerPort: {{ .Values.service.internalPort }}
         env:
         - name: SITE_URL 
-          value: {{ default "http://127.0.0.1:8000" .Values.ingress.hostname | quote }} 
+          value: {{ printf "%s://%s" .Values.ingress.scheme .Values.ingress.hostname | quote }}
         - name: SECRET_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -63,7 +63,7 @@ spec:
         - containerPort: {{ .Values.service.internalPort }}
         env:
         - name: SITE_URL 
-          value: {{ default "http://127.0.0.1:8000" .Values.ingress.hostname | quote }} 
+          value: {{ printf "%s://%s" .Values.ingress.scheme .Values.ingress.hostname | quote }}
         - name: DISABLE_SECURE_SSL_REDIRECT
           value: {{ default "1" .Values.disableSecureSslRedirect | quote }}
         - name: SECURE_COOKIES 

--- a/charts/posthog/templates/workers-deployment.yaml
+++ b/charts/posthog/templates/workers-deployment.yaml
@@ -66,7 +66,7 @@ spec:
         - containerPort: {{ .Values.service.internalPort }}
         env:
         - name: SITE_URL 
-          value: {{ default "http://127.0.0.1:8000" .Values.ingress.hostname | quote }} 
+          value: {{ printf "%s://%s" .Values.ingress.scheme .Values.ingress.hostname | quote }}
         - name: SECRET_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -164,6 +164,7 @@ service:
 ingress:
   enabled: false
   hostname: posthog.local
+  scheme: http
 
   ## Ingress annotations
   ##


### PR DESCRIPTION
Fixes #55 
I recently ran into this same issue, and thought this could be a simple approach to resolving it. 

This PR adds `ingress.scheme` to resolve the `SITE_URL` issue when using https. Previously, the chart only supported http in the `SITE_URL` due to using the ingress. I've added `ingress.scheme` to be used alongside the `SITE_URL`, resolving the previous error. 

