### PR TITLE
added security context for all deployments and migrate job

### DIFF
--- a/charts/posthog/ChartV3.yaml
+++ b/charts/posthog/ChartV3.yaml
@@ -15,7 +15,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.6.0
+version: 1.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/beat-deployment.yaml
+++ b/charts/posthog/templates/beat-deployment.yaml
@@ -50,6 +50,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.beat.securityContext.enabled }}
+      securityContext: {{- omit .Values.beat.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}-beat
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/posthog/templates/metrics-deployment.yaml
+++ b/charts/posthog/templates/metrics-deployment.yaml
@@ -36,6 +36,9 @@ spec:
       {{- if .Values.metrics.schedulerName }}
       schedulerName: "{{ .Values.metrics.schedulerName }}"
       {{- end }}
+      {{- if .Values.metrics.securityContext.enabled }}
+      securityContext: {{- omit .Values.metrics.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}-metrics
         args: 

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -35,6 +35,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.hooks.migrate.securityContext.enabled }}
+      securityContext: {{- omit .Values.hooks.migrate.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
       - name: migrate-job
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -53,6 +53,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.plugins.securityContext.enabled }}
+      securityContext: {{- omit .Values.plugins.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}-plugins
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -50,6 +50,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.web.securityContext.enabled }}
+      securityContext: {{- omit .Values.web.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}-web
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/posthog/templates/workers-deployment.yaml
+++ b/charts/posthog/templates/workers-deployment.yaml
@@ -53,6 +53,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.worker.securityContext.enabled }}
+      securityContext: {{- omit .Values.worker.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}-workers
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -33,6 +33,8 @@ web:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  securityContext:
+    enabled: false
   livenessProbe:
     failureThreshold: 5
     initialDelaySeconds: 50
@@ -67,6 +69,8 @@ beat:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  securityContext:
+    enabled: false
   # priorityClassName: ""
   # schedulerName:
   # Optional extra labels for pod, i.e. redis-client: "true"
@@ -92,6 +96,8 @@ worker:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  securityContext:
+    enabled: false
   # priorityClassName: ""
   # schedulerName:
   # Optional extra labels for pod, i.e. redis-client: "true"
@@ -118,6 +124,8 @@ plugins:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  securityContext:
+    enabled: false
   # priorityClassName: ""
   # schedulerName:
   # Optional extra labels for pod, i.e. redis-client: "true"
@@ -216,6 +224,8 @@ redis:
 ##
 metrics:
   enabled: false
+  securityContext:
+    enabled: false
 
   ## Configure extra options for liveness and readiness probes
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
@@ -277,6 +287,8 @@ hooks:
   affinity: {}
   migrate:
     env: []
+    securityContext:
+      enabled: false
     resources:
       limits:
         memory: 1000Mi


### PR DESCRIPTION
Added security context for all deployments and migrate job.  It is backwards compatible as it is disabled by default. This allows the user to deploy on a Kubernetes cluster that does not allow root images (for example).


Closes #51